### PR TITLE
fix api naming for multiple deployments, fix s3 origin deprecation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,6 @@ jobs:
       - name: "install dependencies"
         run: npm install
       - name: "run oxlint"
-        run: oxlint .
+        run: npx oxlint .
       - name: "run unit tests"
         run: npm run test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,14 +11,13 @@ jobs:
       - uses: actions/setup-python@v5
       - name: set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-#      - uses: actions/cache@v1
-#        with:
-#          path: ~/.cache/pre-commit
-#          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - run: pip3 install pre-commit
-      - name: "install dependencies"
-        run: npm install
+      - name: "install pre-commit"
+        run: pip3 install pre-commit
       - name: "run pre-commit"
         run: pre-commit run --all-files -c .pre-commit-config-ci.yaml
+      - name: "install dependencies"
+        run: npm install
+      - name: "run oxlint"
+        run: oxlint .
       - name: "run unit tests"
         run: npm run test

--- a/.pre-commit-config-ci.yaml
+++ b/.pre-commit-config-ci.yaml
@@ -1,0 +1,5 @@
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: mixed-line-ending
+      - id: trailing-whitespace

--- a/.pre-commit-config-ci.yaml
+++ b/.pre-commit-config-ci.yaml
@@ -1,3 +1,4 @@
+repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "@types/aws-lambda": "^8.10.160",
         "@types/jsrsasign": "^10.5.15",
         "base64url": "^3.0.1",
-        "jsrsasign": "^11.1.0",
-        "oxlint": "^1.41.0"
+        "jsrsasign": "^11.1.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.160",
@@ -39,6 +38,7 @@
         "jest": "^30.2.0",
         "jsii": "^5.9.23",
         "jwt-decode": "^4.0.0",
+        "oxlint": "^1.41.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.9.3"
@@ -3008,6 +3008,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3021,6 +3022,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3034,6 +3036,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3047,6 +3050,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3060,6 +3064,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3073,6 +3078,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3086,6 +3092,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3099,6 +3106,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7042,6 +7050,7 @@
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.41.0.tgz",
       "integrity": "sha512-Dyaoup82uhgAgp5xLNt4dPdvl5eSJTIzqzL7DcKbkooUE4PDViWURIPlSUF8hu5a+sCnNIp/LlQMDsKoyaLTBA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "oxlint": "bin/oxlint"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alliander-opensource/aws-jwt-sts",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alliander-opensource/aws-jwt-sts",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "bundleDependencies": [
         "@aws-lambda-powertools/logger",
         "@aws-sdk/client-kms",
@@ -19,8 +19,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.30.2",
-        "@aws-sdk/client-kms": "^3.974.0",
-        "@aws-sdk/client-s3": "^3.974.0",
+        "@aws-sdk/client-kms": "^3.984.0",
+        "@aws-sdk/client-s3": "^3.984.0",
         "@types/aws-lambda": "^8.10.160",
         "@types/jsrsasign": "^10.5.15",
         "base64url": "^3.0.1",
@@ -29,16 +29,16 @@
       "devDependencies": {
         "@types/aws-lambda": "^8.10.160",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.0.10",
-        "aws-cdk": "^2.1102.0",
-        "aws-cdk-lib": "2.235.1",
+        "@types/node": "^25.2.1",
+        "aws-cdk": "^2.1105.0",
+        "aws-cdk-lib": "2.237.1",
         "aws-sdk-client-mock": "^4.1.0",
         "constructs": "10.4.5",
         "esbuild": "^0.27.2",
         "jest": "^30.2.0",
-        "jsii": "^5.9.23",
+        "jsii": "^5.9.25",
         "jwt-decode": "^4.0.0",
-        "oxlint": "^1.41.0",
+        "oxlint": "^1.43.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.9.3"
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.261",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.261.tgz",
-      "integrity": "sha512-XkKvgG/OxrEYtVTt2Q9gaD58Qn90fnX/dNczL4k6myeii7UgAGPmqh+I+1uKohCWGKIKd+4Gz2xWBL/tPi4YIA==",
+      "version": "2.2.263",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
+      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -366,46 +366,46 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.974.0.tgz",
-      "integrity": "sha512-mr2JEXVN6Kp6LGh+xoMaLZV62uwtBYHVWZ2K0SGlx+u8zQuXE0RoqPvU6osO9Hi5BBIruUHleb1YNUtJ6iM6sw==",
+      "version": "3.984.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.984.0.tgz",
+      "integrity": "sha512-i4QYiF5LcvsaLupPihAIGd1IQ9va0F0NuZkrmkHHrF/HC4MQN56ovt6EpknKxCK3BgHlaPaacrAt9FwND+hsmw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/credential-provider-node": "^3.972.1",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/credential-provider-node": "^3.972.5",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.984.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.4",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
+        "@smithy/core": "^3.22.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -417,35 +417,35 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.974.0.tgz",
-      "integrity": "sha512-X+vpXNJ8cU8Iw1FtDgDHxo9z6RxlXfcTtpdGnKws4rk+tCYKSAor/DG6BRMzbh4E5xAA7DiU1Ny3BTrRRSt/Yg==",
+      "version": "3.984.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.984.0.tgz",
+      "integrity": "sha512-7ny2Slr93Y+QniuluvcfWwyDi32zWQfznynL56Tk0vVh7bWrvS/odm8WP2nInKicRVNipcJHY2YInur6Q/9V0A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/credential-provider-node": "^3.972.1",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.1",
-        "@aws-sdk/middleware-expect-continue": "^3.972.1",
-        "@aws-sdk/middleware-flexible-checksums": "^3.972.1",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-location-constraint": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.1",
-        "@aws-sdk/middleware-ssec": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/signature-v4-multi-region": "3.972.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/credential-provider-node": "^3.972.5",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.3",
+        "@aws-sdk/middleware-expect-continue": "^3.972.3",
+        "@aws-sdk/middleware-flexible-checksums": "^3.972.4",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-location-constraint": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.6",
+        "@aws-sdk/middleware-ssec": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/signature-v4-multi-region": "3.984.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.984.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.4",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
+        "@smithy/core": "^3.22.0",
         "@smithy/eventstream-serde-browser": "^4.2.8",
         "@smithy/eventstream-serde-config-resolver": "^4.3.8",
         "@smithy/eventstream-serde-node": "^4.2.8",
@@ -456,21 +456,21 @@
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/md5-js": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -484,45 +484,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.974.0.tgz",
-      "integrity": "sha512-ci+GiM0c4ULo4D79UMcY06LcOLcfvUfiyt8PzNY0vbt5O8BfCPYf4QomwVgkNcLLCYmroO4ge2Yy1EsLUlcD6g==",
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.982.0.tgz",
+      "integrity": "sha512-qJrIiivmvujdGqJ0ldSUvhN3k3N7GtPesoOI1BSt0fNXovVnMz4C/JmnkhZihU7hJhDvxJaBROLYTU+lpild4w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.982.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.4",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
+        "@smithy/core": "^3.22.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -533,21 +533,38 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.0.tgz",
-      "integrity": "sha512-qy3Fmt8z4PRInM3ZqJmHihQ2tfCdj/MzbGaZpuHjYjgl1/Gcar4Pyp/zzHXh9hGEb61WNbWgsJcDUhnGIiX1TA==",
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
+      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/xml-builder": "^3.972.1",
-        "@smithy/core": "^3.21.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.6.tgz",
+      "integrity": "sha512-pz4ZOw3BLG0NdF25HoB9ymSYyPbMiIjwQJ2aROXRhAzt+b+EOxStfFv8s5iZyP6Kiw7aYhyWxj5G3NhmkoOTKw==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/xml-builder": "^3.972.4",
+        "@smithy/core": "^3.22.0",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-middleware": "^4.2.8",
@@ -573,14 +590,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.1.tgz",
-      "integrity": "sha512-/etNHqnx96phy/SjI0HRC588o4vKH5F0xfkZ13yAATV7aNrb+5gYGNE6ePWafP+FuZ3HkULSSlJFj0AxgrAqYw==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.4.tgz",
+      "integrity": "sha512-/8dnc7+XNMmViEom2xsNdArQxQPSgy4Z/lm6qaFPTrMFesT1bV3PsBhb19n09nmxHdrtQskYmViddUIjUQElXg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -590,19 +607,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.1.tgz",
-      "integrity": "sha512-AeopObGW5lpWbDRZ+t4EAtS7wdfSrHPLeFts7jaBzgIaCCD7TL7jAyAB9Y5bCLOPF+17+GL54djCCsjePljUAw==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.6.tgz",
+      "integrity": "sha512-5ERWqRljiZv44AIdvIRQ3k+EAV0Sq2WeJHvXuK7gL7bovSxOf8Al7MLH7Eh3rdovH4KHFnlIty7J71mzvQBl5Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/util-stream": "^4.5.10",
         "tslib": "^2.6.2"
@@ -612,21 +629,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.1.tgz",
-      "integrity": "sha512-OdbJA3v+XlNDsrYzNPRUwr8l7gw1r/nR8l4r96MDzSBDU8WEo8T6C06SvwaXR8SpzsjO3sq5KMP86wXWg7Rj4g==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.4.tgz",
+      "integrity": "sha512-eRUg+3HaUKuXWn/lEMirdiA5HOKmEl8hEHVuszIDt2MMBUKgVX5XNGmb3XmbgU17h6DZ+RtjbxQpjhz3SbTjZg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/credential-provider-env": "^3.972.1",
-        "@aws-sdk/credential-provider-http": "^3.972.1",
-        "@aws-sdk/credential-provider-login": "^3.972.1",
-        "@aws-sdk/credential-provider-process": "^3.972.1",
-        "@aws-sdk/credential-provider-sso": "^3.972.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/credential-provider-env": "^3.972.4",
+        "@aws-sdk/credential-provider-http": "^3.972.6",
+        "@aws-sdk/credential-provider-login": "^3.972.4",
+        "@aws-sdk/credential-provider-process": "^3.972.4",
+        "@aws-sdk/credential-provider-sso": "^3.972.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
+        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -638,15 +655,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.1.tgz",
-      "integrity": "sha512-CccqDGL6ZrF3/EFWZefvKW7QwwRdxlHUO8NVBKNVcNq6womrPDvqB6xc9icACtE0XB0a7PLoSTkAg8bQVkTO2w==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.4.tgz",
+      "integrity": "sha512-nLGjXuvWWDlQAp505xIONI7Gam0vw2p7Qu3P6on/W2q7rjJXtYjtpHbcsaOjJ/pAju3eTvEQuSuRedcRHVQIAQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -658,19 +675,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.1.tgz",
-      "integrity": "sha512-DwXPk9GfuU/xG9tmCyXFVkCr6X3W8ZCoL5Ptb0pbltEx1/LCcg7T+PBqDlPiiinNCD6ilIoMJDWsnJ8ikzZA7Q==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.5.tgz",
+      "integrity": "sha512-VWXKgSISQCI2GKN3zakTNHSiZ0+mux7v6YHmmbLQp/o3fvYUQJmKGcLZZzg2GFA+tGGBStplra9VFNf/WwxpYg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.1",
-        "@aws-sdk/credential-provider-http": "^3.972.1",
-        "@aws-sdk/credential-provider-ini": "^3.972.1",
-        "@aws-sdk/credential-provider-process": "^3.972.1",
-        "@aws-sdk/credential-provider-sso": "^3.972.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/credential-provider-env": "^3.972.4",
+        "@aws-sdk/credential-provider-http": "^3.972.6",
+        "@aws-sdk/credential-provider-ini": "^3.972.4",
+        "@aws-sdk/credential-provider-process": "^3.972.4",
+        "@aws-sdk/credential-provider-sso": "^3.972.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -682,14 +699,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.1.tgz",
-      "integrity": "sha512-bi47Zigu3692SJwdBvo8y1dEwE6B61stCwCFnuRWJVTfiM84B+VTSCV661CSWJmIZzmcy7J5J3kWyxL02iHj0w==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.4.tgz",
+      "integrity": "sha512-TCZpWUnBQN1YPk6grvd5x419OfXjHvhj5Oj44GYb84dOVChpg/+2VoEj+YVA4F4E/6huQPNnX7UYbTtxJqgihw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -700,16 +717,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.1.tgz",
-      "integrity": "sha512-dLZVNhM7wSgVUFsgVYgI5hb5Z/9PUkT46pk/SHrSmUqfx6YDvoV4YcPtaiRqviPpEGGiRtdQMEadyOKIRqulUQ==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.4.tgz",
+      "integrity": "sha512-wzsGwv9mKlwJ3vHLyembBvGE/5nPUIwRR2I51B1cBV4Cb4ql9nIIfpmHzm050XYTY5fqTOKJQnhLj7zj89VG8g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.974.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/token-providers": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/client-sso": "3.982.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/token-providers": "3.982.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -720,15 +737,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.1.tgz",
-      "integrity": "sha512-YMDeYgi0u687Ay0dAq/pFPKuijrlKTgsaB/UATbxCs/FzZfMiG4If5ksywHmmW7MiYUF8VVv+uou3TczvLrN4w==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.4.tgz",
+      "integrity": "sha512-hIzw2XzrG8jzsUSEatehmpkd5rWzASg5IHUfA+m01k/RtvfAML7ZJVVohuKdhAYx+wV2AThLiQJVzqn7F0khrw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -739,14 +756,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.1.tgz",
-      "integrity": "sha512-YVvoitBdE8WOpHqIXvv49efT73F4bJ99XH2bi3Dn3mx7WngI4RwHwn/zF5i0q1Wdi5frGSCNF3vuh+pY817//w==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.3.tgz",
+      "integrity": "sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-arn-parser": "^3.972.1",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -758,13 +775,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.1.tgz",
-      "integrity": "sha512-6lfl2/J/kutzw/RLu1kjbahsz4vrGPysrdxWaw8fkjLYG+6M6AswocIAZFS/LgAVi/IWRwPTx9YC0/NH2wDrSw==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.3.tgz",
+      "integrity": "sha512-4msC33RZsXQpUKR5QR4HnvBSNCPLGHmB55oDiROqqgyOc+TOfVu2xgi5goA7ms6MdZLeEh2905UfWMnMMF4mRg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -774,18 +791,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.972.1.tgz",
-      "integrity": "sha512-kjVVREpqeUkYQsXr78AcsJbEUlxGH7+H6yS7zkjrnu6HyEVxbdSndkKX6VpKneFOihjCAhIXlk4wf3butDHkNQ==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.972.4.tgz",
+      "integrity": "sha512-xOxsUkF3O3BtIe3tf54OpPo94eZepjFm3z0Dd2TZKbsPxMiRTFXurC04wJ58o/wPW9YHVO9VqZik3MfoPfrKlw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
         "@aws-sdk/crc64-nvme": "3.972.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/is-array-buffer": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
@@ -800,13 +817,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.1.tgz",
-      "integrity": "sha512-/R82lXLPmZ9JaUGSUdKtBp2k/5xQxvBT3zZWyKiBOhyulFotlfvdlrO8TnqstBimsl4lYEYySDL+W6ldFh6ALg==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
+      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -816,13 +833,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.1.tgz",
-      "integrity": "sha512-YisPaCbvBk9gY5aUI8jDMDKXsLZ9Fet0WYj1MviK8tZYMgxBIYHM6l3O/OHaAIujojZvamd9F3haYYYWp5/V3w==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.3.tgz",
+      "integrity": "sha512-nIg64CVrsXp67vbK0U1/Is8rik3huS3QkRHn2DRDx4NldrEFMgdkZGI/+cZMKD9k4YOS110Dfu21KZLHrFA/1g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -831,13 +848,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.1.tgz",
-      "integrity": "sha512-JGgFl6cHg9G2FHu4lyFIzmFN8KESBiRr84gLC3Aeni0Gt1nKm+KxWLBuha/RPcXxJygGXCcMM4AykkIwxor8RA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
+      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -846,13 +863,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.1.tgz",
-      "integrity": "sha512-taGzNRe8vPHjnliqXIHp9kBgIemLE/xCaRTMH1NH0cncHeaPcjxtnCroAAM9aOlPuKvBe2CpZESyvM1+D8oI7Q==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
+      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -863,20 +880,20 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.1.tgz",
-      "integrity": "sha512-q/hK0ZNf/aafFRv2wIlDM3p+izi5cXwktVNvRvW646A0MvVZmT4/vwadv/jPA9AORFbnpyf/0luxiMz181f9yg==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.6.tgz",
+      "integrity": "sha512-Xq7wM6kbgJN1UO++8dvH/efPb1nTwWqFCpZCR7RCLOETP7xAUAhVo7JmsCnML5Di/iC4Oo5VrJ4QmkYcMZniLw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-arn-parser": "^3.972.1",
-        "@smithy/core": "^3.21.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
+        "@smithy/core": "^3.22.0",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/util-config-provider": "^4.2.0",
         "@smithy/util-middleware": "^4.2.8",
@@ -889,13 +906,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.1.tgz",
-      "integrity": "sha512-fLtRTPd/MxJT2drJKft2GVGKm35PiNEeQ1Dvz1vc/WhhgAteYrp4f1SfSgjgLaYWGMExESJL4bt8Dxqp6tVsog==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.3.tgz",
+      "integrity": "sha512-dU6kDuULN3o3jEHcjm0c4zWJlY1zWVkjG9NPe9qxYLLpcbdj5kRYBS2DdWYD+1B9f910DezRuws7xDEqKkHQIg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -904,16 +921,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.1.tgz",
-      "integrity": "sha512-6SVg4pY/9Oq9MLzO48xuM3lsOb8Rxg55qprEtFRpkUmuvKij31f5SQHEGxuiZ4RqIKrfjr2WMuIgXvqJ0eJsPA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.6.tgz",
+      "integrity": "sha512-TehLN8W/kivl0U9HcS+keryElEWORROpghDXZBLfnb40DXM7hx/i+7OOjkogXQOF3QtUraJVRkHQ07bPhrWKlw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@smithy/core": "^3.21.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.982.0",
+        "@smithy/core": "^3.22.0",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -922,46 +939,63 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
+      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.974.0.tgz",
-      "integrity": "sha512-k3dwdo/vOiHMJc9gMnkPl1BA5aQfTrZbz+8fiDkWrPagqAioZgmo5oiaOaeX0grObfJQKDtcpPFR4iWf8cgl8Q==",
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.982.0.tgz",
+      "integrity": "sha512-VVkaH27digrJfdVrT64rjkllvOp4oRiZuuJvrylLXAKl18ujToJR7AqpDldL/LS63RVne3QWIpkygIymxFtliQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.1",
-        "@aws-sdk/middleware-logger": "^3.972.1",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/region-config-resolver": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
-        "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.1",
-        "@aws-sdk/util-user-agent-node": "^3.972.1",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.982.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.4",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.21.0",
+        "@smithy/core": "^3.22.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-retry": "^4.4.26",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.11",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.25",
-        "@smithy/util-defaults-mode-node": "^4.2.28",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -972,14 +1006,31 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.1.tgz",
-      "integrity": "sha512-voIY8RORpxLAEgEkYaTFnkaIuRwVBEc+RjVZYcSSllPV+ZEKAacai6kNhJeE3D70Le+JCfvRb52tng/AVHY+jQ==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
+      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
+      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -990,110 +1041,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.972.0.tgz",
-      "integrity": "sha512-2udiRijmjpN81Pvajje4TsjbXDZNP6K9bYUanBYH8hXa/tZG5qfGCySD+TyX0sgDxCQmEDMg3LaQdfjNHBDEgQ==",
+      "version": "3.984.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.984.0.tgz",
+      "integrity": "sha512-TaWbfYCwnuOSvDSrgs7QgoaoXse49E7LzUkVOUhoezwB7bkmhp+iojADm7UepCEu4021SquD7NG1xA+WCvmldA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.6",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
         "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/core": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.972.0.tgz",
-      "integrity": "sha512-nEeUW2M9F+xdIaD98F5MBcQ4ITtykj3yKbgFZ6J0JtL3bq+Z90szQ6Yy8H/BLPYXTs3V4n9ifnBo8cprRDiE6A==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.972.0",
-        "@aws-sdk/xml-builder": "3.972.0",
-        "@smithy/core": "^3.20.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.0.tgz",
-      "integrity": "sha512-0bcKFXWx+NZ7tIlOo7KjQ+O2rydiHdIQahrq+fN6k9Osky29v17guy68urUKfhTobR6iY6KvxkroFWaFtTgS5w==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
-        "@aws-sdk/util-arn-parser": "3.972.0",
-        "@smithy/core": "^3.20.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.0.tgz",
-      "integrity": "sha512-RM5Mmo/KJ593iMSrALlHEOcc9YOIyOsDmS5x2NLOMdEmzv1o00fcpAkCQ02IGu1eFneBFT7uX0Mpag0HI+Cz2g==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.0.tgz",
-      "integrity": "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1101,15 +1059,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.974.0.tgz",
-      "integrity": "sha512-cBykL0LiccKIgNhGWvQRTPvsBLPZxnmJU3pYxG538jpFX8lQtrCy1L7mmIHNEdxIdIGEPgAEHF8/JQxgBToqUQ==",
+      "version": "3.982.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.982.0.tgz",
+      "integrity": "sha512-v3M0KYp2TVHYHNBT7jHD9lLTWAdS9CaWJ2jboRKt0WAB65bA7iUEpR+k4VqKYtpQN4+8kKSc4w+K6kUNZkHKQw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.0",
-        "@aws-sdk/nested-clients": "3.974.0",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -1120,9 +1078,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.0.tgz",
-      "integrity": "sha512-jYIdB7a7jhRTvyb378nsjyvJh1Si+zVduJ6urMNGpz8RjkmHZ+9vM2H07XaIB2Cfq0GhJRZYOfUCH8uqQhqBkQ==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1134,9 +1092,9 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.1.tgz",
-      "integrity": "sha512-XnNit6H9PPHhqUXW/usjX6JeJ6Pm8ZNqivTjmNjgWHeOfVpblUc/MTic02UmCNR0jJLPjQ3mBKiMen0tnkNQjQ==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
+      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1147,30 +1105,16 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.972.0.tgz",
-      "integrity": "sha512-6JHsl1V/a1ZW8D8AFfd4R52fwZPnZ5H4U6DS8m/bWT8qad72NvbOFAC7U2cDtFs2TShqUO3TEiX/EJibtY3ijg==",
+      "version": "3.984.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.984.0.tgz",
+      "integrity": "sha512-9ebjLA0hMKHeVvXEtTDCCOBtwjb0bOXiuUV06HNeVdgAjH6gj4x4Zwt4IBti83TiyTGOCl5YfZqGx4ehVsasbQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1191,27 +1135,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.1.tgz",
-      "integrity": "sha512-IgF55NFmJX8d9Wql9M0nEpk2eYbuD8G4781FN4/fFgwTXBn86DvlZJuRWDCMcMqZymnBVX7HW9r+3r9ylqfW0w==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
+      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.1.tgz",
-      "integrity": "sha512-oIs4JFcADzoZ0c915R83XvK2HltWupxNsXUIuZse2rgk7b97zTpkxaqXiH0h9ylh31qtgo/t8hp4tIqcsMrEbQ==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.4.tgz",
+      "integrity": "sha512-3WFCBLiM8QiHDfosQq3Py+lIMgWlFWwFQliUHUqwEiRqLnKyhgbU3AKa7AWJF7lW2Oc/2kFNY4MlAYVnVc0i8A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.1",
-        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/types": "^3.973.1",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -1229,14 +1173,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.1.tgz",
-      "integrity": "sha512-6zZGlPOqn7Xb+25MAXGb1JhgvaC5HjZj6GzszuVrnEgbhvzBRFGKYemuHBV4bho+dtqeYKPgaZUv7/e80hIGNg==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
+      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.2.5",
+        "fast-xml-parser": "5.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2938,9 +2882,9 @@
       }
     },
     "node_modules/@jsii/check-node": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.125.0.tgz",
-      "integrity": "sha512-vhFFXFiq2JPE7KoUC54/VsASiuWMu0+rS3BExteIZ3zGu8TdcSLh9aHbfYbww5MjpDTWxxW8TgXumgFTSlyT0Q==",
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.126.0.tgz",
+      "integrity": "sha512-JCEiImb536Fbl9az3c0/KSfji4m/IIi/V1kWrlXnJxFGO98FaXJUQsDsXWKbr6YVN+9Eltwwpir08hDvmuT5Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2952,9 +2896,9 @@
       }
     },
     "node_modules/@jsii/spec": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.125.0.tgz",
-      "integrity": "sha512-FneFGrzBMAUjLM1Z4LY3VuWhUrBWUgfrPYLsjnC11HwcMgE1LvVi26QIuTKvV0KWCStIJu4N2TkOEc82b0hbUQ==",
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.126.0.tgz",
+      "integrity": "sha512-TWCMhogxq5mR1BJaksRtB8ciUQ9vMYSHoQT2t5pKHUtNAJnyFHzWNO7EHr8eQAj74k8P5XeGkOWsfpkQxHiHMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2963,30 +2907,6 @@
       "engines": {
         "node": ">= 14.17.0"
       }
-    },
-    "node_modules/@jsii/spec/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@jsii/spec/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3002,9 +2922,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.41.0.tgz",
-      "integrity": "sha512-K0Bs0cNW11oWdSrKmrollKF44HMM2HKr4QidZQHMlhJcSX8pozxv0V5FLdqB4sddzCY0J9Wuuw+oRAfR8sdRwA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.43.0.tgz",
+      "integrity": "sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==",
       "cpu": [
         "arm64"
       ],
@@ -3016,9 +2936,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.41.0.tgz",
-      "integrity": "sha512-1LCCXCe9nN8LbrJ1QOGari2HqnxrZrveYKysWDIg8gFsQglIg00XF/8lRbA0kWHMdLgt4X0wfNYhhFz+c3XXLQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.43.0.tgz",
+      "integrity": "sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==",
       "cpu": [
         "x64"
       ],
@@ -3030,9 +2950,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.41.0.tgz",
-      "integrity": "sha512-Fow7H84Bs8XxuaK1yfSEWBC8HI7rfEQB9eR2A0J61un1WgCas7jNrt1HbT6+p6KmUH2bhR+r/RDu/6JFAvvj4g==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.43.0.tgz",
+      "integrity": "sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==",
       "cpu": [
         "arm64"
       ],
@@ -3044,9 +2964,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.41.0.tgz",
-      "integrity": "sha512-WoRRDNwgP5W3rjRh42Zdx8ferYnqpKoYCv2QQLenmdrLjRGYwAd52uywfkcS45mKEWHeY1RPwPkYCSROXiGb2w==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.43.0.tgz",
+      "integrity": "sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==",
       "cpu": [
         "arm64"
       ],
@@ -3058,9 +2978,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.41.0.tgz",
-      "integrity": "sha512-75k3CKj3fOc/a/2aSgO81s3HsTZOFROthPJ+UI2Oatic1LhvH6eKjKfx3jDDyVpzeDS2qekPlc/y3N33iZz5Og==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.43.0.tgz",
+      "integrity": "sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==",
       "cpu": [
         "x64"
       ],
@@ -3072,9 +2992,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.41.0.tgz",
-      "integrity": "sha512-8r82eBwGPoAPn67ZvdxTlX/Z3gVb+ZtN6nbkyFzwwHWAh8yGutX+VBcVkyrePSl6XgBP4QAaddPnHmkvJjqY0g==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.43.0.tgz",
+      "integrity": "sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==",
       "cpu": [
         "x64"
       ],
@@ -3086,9 +3006,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.41.0.tgz",
-      "integrity": "sha512-aK+DAcckQsNCOXKruatyYuY/ROjNiRejQB1PeJtkZwM21+8rV9ODYbvKNvt0pW+YCws7svftBSFMCpl3ke2unw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.43.0.tgz",
+      "integrity": "sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==",
       "cpu": [
         "arm64"
       ],
@@ -3100,9 +3020,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.41.0.tgz",
-      "integrity": "sha512-dVBXkZ6MGLd3owV7jvuqJsZwiF3qw7kEkDVsYVpS/O96eEvlHcxVbaPjJjrTBgikXqyC22vg3dxBU7MW0utGfw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.43.0.tgz",
+      "integrity": "sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==",
       "cpu": [
         "x64"
       ],
@@ -3253,9 +3173,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.21.1.tgz",
-      "integrity": "sha512-NUH8R4O6FkN8HKMojzbGg/5pNjsfTjlMmeFclyPfPaXXUrbr5TzhWgbf7t92wfrpCHRgpjyz7ffASIS3wX28aA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.0.tgz",
+      "integrity": "sha512-6vjCHD6vaY8KubeNw2Fg3EK0KLGQYdldG4fYgQmA0xSW0dJ8G2xFhSOdrlUakWVoP5JuWHtFODg3PNd/DN3FDA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3488,13 +3408,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.11.tgz",
-      "integrity": "sha512-/WqsrycweGGfb9sSzME4CrsuayjJF6BueBmkKlcbeU5q18OhxRrvvKlmfw3tpDsK5ilx2XUJvoukwxHB0nHs/Q==",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.12.tgz",
+      "integrity": "sha512-9JMKHVJtW9RysTNjcBZQHDwB0p3iTP6B1IfQV4m+uCevkVd/VuLgwfqk5cnI4RHcp4cPwoIvxQqN4B1sxeHo8Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.21.1",
+        "@smithy/core": "^3.22.0",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -3508,16 +3428,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.27.tgz",
-      "integrity": "sha512-xFUYCGRVsfgiN5EjsJJSzih9+yjStgMTCLANPlf0LVQkPDYCe0hz97qbdTZosFOiYlGBlHYityGRxrQ/hxhfVQ==",
+      "version": "4.4.29",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.29.tgz",
+      "integrity": "sha512-bmTn75a4tmKRkC5w61yYQLb3DmxNzB8qSVu9SbTYqW6GAL0WXO2bDZuMAn/GJSbOdHEdjZvWxe+9Kk015bw6Cg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -3695,14 +3615,14 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.12.tgz",
-      "integrity": "sha512-VKO/HKoQ5OrSHW6AJUmEnUKeXI1/5LfCwO9cwyao7CmLvGnZeM1i36Lyful3LK1XU7HwTVieTqO1y2C/6t3qtA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.1.tgz",
+      "integrity": "sha512-SERgNg5Z1U+jfR6/2xPYjSEHY1t3pyTHC/Ma3YQl6qWtmiL42bvNId3W/oMUWIwu7ekL2FMPdqAmwbQegM7HeQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.21.1",
-        "@smithy/middleware-endpoint": "^4.4.11",
+        "@smithy/core": "^3.22.0",
+        "@smithy/middleware-endpoint": "^4.4.12",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -3810,14 +3730,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.26.tgz",
-      "integrity": "sha512-vva0dzYUTgn7DdE0uaha10uEdAgmdLnNFowKFjpMm6p2R0XDk5FHPX3CBJLzWQkQXuEprsb0hGz9YwbicNWhjw==",
+      "version": "4.3.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.28.tgz",
+      "integrity": "sha512-/9zcatsCao9h6g18p/9vH9NIi5PSqhCkxQ/tb7pMgRFnqYp9XUOyOlGPDMHzr8n5ih6yYgwJEY2MLEobUgi47w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -3826,9 +3746,9 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.29",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.29.tgz",
-      "integrity": "sha512-c6D7IUBsZt/aNnTBHMTf+OVh+h/JcxUUgfTcIJaWRe6zhOum1X+pNKSZtZ+7fbOn5I99XVFtmrnXKv8yHHErTQ==",
+      "version": "4.2.31",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.31.tgz",
+      "integrity": "sha512-JTvoApUXA5kbpceI2vuqQzRjeTbLpx1eoa5R/YEZbTgtxvIB7AQZxFJ0SEyfCpgPCyVV9IT7we+ytSeIB3CyWA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3836,7 +3756,7 @@
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/smithy-client": "^4.11.1",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -4103,9 +4023,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
+      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4449,6 +4369,23 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -4510,9 +4447,9 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.1102.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1102.0.tgz",
-      "integrity": "sha512-M/TeLiZERo88hB7FIbT+LyzKQBQuxiGW34oSSfy9+rYTuGwJrO9z6ZZrBNO8/jODT2iR7z0pa3CPsdUVC71oOw==",
+      "version": "2.1105.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1105.0.tgz",
+      "integrity": "sha512-1RY2UZJv31XYobEGFHQEb7c2HXNzDbHuHqdnfdYyygvZW4Nrm8MJCW42lqItQCn+wF52Ixc7r2VR5eR4YGtVhA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4520,15 +4457,12 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.235.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.235.1.tgz",
-      "integrity": "sha512-qKAsbunxtveIOIaeJSBgH2PZgdIiPkKtfsa+BxeNDOv2idw6Oa0dJW3Q0sdu8XBopY1KZI2Owrg8r56BOyyohA==",
+      "version": "2.237.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.237.1.tgz",
+      "integrity": "sha512-RH8mWHLBtc14stkeUF0gFLaWdS5iS2AHUHnoT5B5LLZfEkYP9G43LjJs0AMmpdlQ5/ZQVvCZ+VB83Q9vLxILRw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4545,7 +4479,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.261",
+        "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
         "@aws-cdk/cloud-assembly-schema": "^48.20.0",
         "@balena/dockerignore": "^1.0.2",
@@ -5619,9 +5553,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",
@@ -5702,21 +5636,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -6733,14 +6652,14 @@
       }
     },
     "node_modules/jsii": {
-      "version": "5.9.23",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.9.23.tgz",
-      "integrity": "sha512-bIPRjOVyBRFl3cmx0kcnTqt3abMazlQvpq67Oix9Ku0jpICaXQv0OJoL/qaUkSl8QXgalUzNOUuxMBjZi680Yw==",
+      "version": "5.9.25",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.9.25.tgz",
+      "integrity": "sha512-jh453ABM8bAHsC1jJyeKNPp5Aj4GsTiH2l+whwZ6WUEer/ChJStfzex3SETWt9+NmRXv5/WWyxYlxQ11BSNa2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/check-node": "1.125.0",
-        "@jsii/spec": "1.125.0",
+        "@jsii/check-node": "1.126.0",
+        "@jsii/spec": "1.126.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
@@ -6763,6 +6682,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -7047,9 +6973,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.41.0.tgz",
-      "integrity": "sha512-Dyaoup82uhgAgp5xLNt4dPdvl5eSJTIzqzL7DcKbkooUE4PDViWURIPlSUF8hu5a+sCnNIp/LlQMDsKoyaLTBA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.43.0.tgz",
+      "integrity": "sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7062,17 +6988,17 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.41.0",
-        "@oxlint/darwin-x64": "1.41.0",
-        "@oxlint/linux-arm64-gnu": "1.41.0",
-        "@oxlint/linux-arm64-musl": "1.41.0",
-        "@oxlint/linux-x64-gnu": "1.41.0",
-        "@oxlint/linux-x64-musl": "1.41.0",
-        "@oxlint/win32-arm64": "1.41.0",
-        "@oxlint/win32-x64": "1.41.0"
+        "@oxlint/darwin-arm64": "1.43.0",
+        "@oxlint/darwin-x64": "1.43.0",
+        "@oxlint/linux-arm64-gnu": "1.43.0",
+        "@oxlint/linux-arm64-musl": "1.43.0",
+        "@oxlint/linux-x64-gnu": "1.43.0",
+        "@oxlint/linux-x64-musl": "1.43.0",
+        "@oxlint/win32-arm64": "1.43.0",
+        "@oxlint/win32-x64": "1.43.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.11.1"
+        "oxlint-tsgolint": ">=0.11.2"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alliander-opensource/aws-jwt-sts",
   "license": "MIT",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": {
     "name": "Alliander NV"
   },

--- a/package.json
+++ b/package.json
@@ -45,28 +45,28 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.160",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.0.10",
-    "aws-cdk": "^2.1102.0",
-    "aws-cdk-lib": "2.235.1",
+    "@types/node": "^25.2.1",
+    "aws-cdk": "^2.1105.0",
+    "aws-cdk-lib": "2.237.1",
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "10.4.5",
     "esbuild": "^0.27.2",
     "jest": "^30.2.0",
-    "jsii": "^5.9.23",
+    "jsii": "^5.9.25",
     "jwt-decode": "^4.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.3",
-    "oxlint": "^1.41.0"
+    "oxlint": "^1.43.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.202.0",
-    "constructs": "^10.4.2"
+    "aws-cdk-lib": "2.237.1",
+    "constructs": "10.4.5"
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.30.2",
-    "@aws-sdk/client-kms": "^3.974.0",
-    "@aws-sdk/client-s3": "^3.974.0",
+    "@aws-sdk/client-kms": "^3.984.0",
+    "@aws-sdk/client-s3": "^3.984.0",
     "@types/aws-lambda": "^8.10.160",
     "@types/jsrsasign": "^10.5.15",
     "base64url": "^3.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,13 @@ export interface AwsJwtStsProps {
    * This certificate is used for the token api and should be in the same region as the API Gateway
    */
   readonly tokenCertificate?: ICertificate;
+
+  /**
+   * Optional custom name for the API Gateway
+   * 
+   * @default 'jwk-sts-api'
+   */
+  readonly jwkApiName?: string;
 }
 
 export class AwsJwtSts extends Construct {
@@ -161,6 +168,7 @@ export class AwsJwtSts extends Construct {
     const oidcSubdomain = props.oidcSubdomain ? props.oidcSubdomain : 'oidc'
     const tokenSubdomain = props.tokenSubdomain ? props.tokenSubdomain : 'token'
     const architecture = props.architecture ? props.architecture : lambda.Architecture.X86_64
+    const jwkApiName = props.jwkApiName ? props.jwkApiName : 'jwk-sts-api'
     let oidcDomainName = ''
     let tokenDomainName = ''
 
@@ -437,7 +445,7 @@ export class AwsJwtSts extends Construct {
     // Create API
     const api = new apigateway.LambdaRestApi(this, 'jwk-sts-api', {
       description: 'STS Token API Gateway',
-      restApiName: `jwk-sts-api-${cdk.Stack.of(this).stackName}`,
+      restApiName: jwkApiName,
       handler: sign,
       defaultMethodOptions: {
         authorizationType: apigateway.AuthorizationType.IAM

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export interface AwsJwtStsProps {
 
   /**
    * Optional custom name for the API Gateway
-   * 
+   *
    * @default 'jwk-sts-api'
    */
   readonly jwkApiName?: string;

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -204,3 +204,28 @@ test('can create the lambdas with a different architecture', () => {
     Architectures: [cdk.aws_lambda.Architecture.ARM_64.toString()]
   }))
 })
+
+test('creates sts construct with custom api name', () => {
+  const stack = new cdk.Stack()
+  new AwsJwtSts(stack, 'WithCustomApiName', {
+    defaultAudience: 'api://default-aud',
+    jwkApiName: 'custom-api-name'
+  })
+
+  const template = Template.fromStack(stack)
+  template.hasResourceProperties('AWS::ApiGateway::RestApi', Match.objectLike({
+    Name: 'custom-api-name'
+  }))
+})
+
+test('creates sts construct with default api name', () => {
+  const stack = new cdk.Stack()
+  new AwsJwtSts(stack, 'WithDefaultApiName', {
+    defaultAudience: 'api://default-aud'
+  })
+
+  const template = Template.fromStack(stack)
+  template.hasResourceProperties('AWS::ApiGateway::RestApi', Match.objectLike({
+    Name: 'jwk-sts-api'
+  }))
+})


### PR DESCRIPTION
Updated OAI to OAC for compliance with AWS standards and avoiding deprecation 
Updated the s3 origin accordingly
Added ability to rename the api (gateway) to facilitate clearer cloudwatch statistics